### PR TITLE
Fix RSpec format option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --color
---format=nested
+--format documentation
 --backtrace
 


### PR DESCRIPTION
Currently RSpec's format option is set to "nested" which is not one of the available options. And a test cannot be run. This fix changes it to one of the available options "documentation."
