### PR TITLE
require json to fix get_access_token

### DIFF
--- a/lib/typetalk/api.rb
+++ b/lib/typetalk/api.rb
@@ -1,4 +1,5 @@
 require 'typetalk/connection'
+require 'json'
 
 module Typetalk
 


### PR DESCRIPTION
this is a fix for get_access_token.
to_json needs `require 'json'`.

i encountered:
```
typetalk-0.0.4/lib/typetalk/api.rb:20:in `access_token': undefined method `expires_in'
```
