### PR TITLE
Support showLinkMeta property to post a message

### DIFF
--- a/lib/typetalk/api/message.rb
+++ b/lib/typetalk/api/message.rb
@@ -14,6 +14,7 @@ module Typetalk
           body = {}
           body[:message] = message
           body[:replyTo] = options[:reply_to] unless options[:reply_to].nil?
+          body[:showLinkMeta] = options[:show_link_meta] unless options[:show_link_meta].nil?
           body.merge! to_request_params(:fileKeys, options[:file_keys])
           body.merge! to_request_params(:talkIds, options[:talk_ids])
           req.body = body

--- a/lib/typetalk/api/message.rb
+++ b/lib/typetalk/api/message.rb
@@ -6,7 +6,7 @@ module Typetalk
     module Message
 
       def post_message(topic_id, message, options={})
-        options = {token:nil, reply_to:nil, file_keys:nil, talk_ids:nil}.merge(options)
+        options = {token:nil, reply_to:nil, show_link_meta:nil, file_keys:nil, talk_ids:nil}.merge(options)
 
         response = connection.post do |req|
           req.url "#{endpoint}/topics/#{topic_id}"


### PR DESCRIPTION
Typetalk Post message API support to not show OGP data of URL included in message. 
https://developer.nulab-inc.com/docs/typetalk/api/1/post-message/

| Name | Type | Description 
 -- | -- | --
| showLinkMeta (Optional) | Boolean | show OGP data of URL included in message. default value: true

This PR allows to pass the option.
Response is same with or without the option.

I would like you to release new version after you review and merge this PR.
Because [fluent-plugin-typetalk](https://github.com/nulab/fluent-plugin-typetalk) wants to support the option.


